### PR TITLE
Added husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+cd polaris-fe && npm run format:fix

--- a/Polaris-FE/components/Collapsible.tsx
+++ b/Polaris-FE/components/Collapsible.tsx
@@ -12,6 +12,7 @@ export function Collapsible({
   title,
 }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
+
   const theme = useColorScheme() ?? 'light';
 
   return (

--- a/Polaris-FE/package-lock.json
+++ b/Polaris-FE/package-lock.json
@@ -38,6 +38,7 @@
         "@types/jest": "^29.5.12",
         "@types/react": "~18.3.12",
         "@types/react-test-renderer": "^18.3.0",
+        "husky": "^9.1.7",
         "jest": "^29.2.1",
         "jest-expo": "~52.0.3",
         "prettier": "^3.4.2",
@@ -7389,6 +7390,21 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/Polaris-FE/package.json
+++ b/Polaris-FE/package.json
@@ -12,7 +12,8 @@
     "ci-test": "jest",
     "lint": "expo lint",
     "format:check": "prettier --check .",
-    "format:fix": "prettier --write ."
+    "format:fix": "prettier --write .",
+     "prepare": "cd .. && husky"
   },
   "jest": {
     "preset": "jest-expo"
@@ -48,6 +49,7 @@
     "@types/jest": "^29.5.12",
     "@types/react": "~18.3.12",
     "@types/react-test-renderer": "^18.3.0",
+    "husky": "^9.1.7",
     "jest": "^29.2.1",
     "jest-expo": "~52.0.3",
     "prettier": "^3.4.2",


### PR DESCRIPTION
# Added Husky pre-commit hook

## Summary
This PR introduces the addition of a pre-commit hook which will run the following script: `npm run format:fix`

## Description
- Installed Husky and followed the following steps: https://typicode.github.io/husky/get-started.html

## How Was This Tested?
1. Manual Test (see Screenshot below)
2. Unit Test : n/a

## Screenshots
1. Example of the pre-commit hook formatting the files: 
![image](https://github.com/user-attachments/assets/920b52f2-5385-43a5-928d-79792a9256e8)
