### PR TITLE
Made Current Building colors update with the theme

### DIFF
--- a/Polaris-FE/components/Map.tsx
+++ b/Polaris-FE/components/Map.tsx
@@ -24,6 +24,8 @@ export const MapComponent: React.FC<MapComponentProps> = ({
   const currentBuilding = useCurrentBuilding();
   const { theme } = useTheme();
   const fillColor = theme.colors.primary;
+  const currentBuildingFillColor = theme.colors.currentBuildingFillColor;
+  const currentBuildingStrokeColor = theme.colors.currentBuildingStrokeColor;
   return (
     <View style={styles.container}>
       <MapView
@@ -64,8 +66,8 @@ export const MapComponent: React.FC<MapComponentProps> = ({
                 },
               ],
             }}
-            fillColor="rgba(0, 0, 255, 0.5)"
-            strokeColor="rgba(0, 0, 255, 1)"
+            fillColor={currentBuildingFillColor}
+            strokeColor={currentBuildingStrokeColor}
             strokeWidth={3}
           />
         )}

--- a/Polaris-FE/components/Map.tsx
+++ b/Polaris-FE/components/Map.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapView, { Geojson, LatLng, Region } from 'react-native-maps';
+import MapView, { Geojson, Region } from 'react-native-maps';
 import { StyleSheet, View } from 'react-native';
 import { downtownBuildings, loyolaBuildings } from '@/constants/buildings';
 import { Buildings } from '@/components/Buildings/Buildings';
@@ -23,9 +23,7 @@ export const MapComponent: React.FC<MapComponentProps> = ({
 
   const currentBuilding = useCurrentBuilding();
   const { theme } = useTheme();
-  const fillColor = theme.colors.primary;
-  const currentBuildingFillColor = theme.colors.currentBuildingFillColor;
-  const currentBuildingStrokeColor = theme.colors.currentBuildingStrokeColor;
+
   return (
     <View style={styles.container}>
       <MapView
@@ -43,11 +41,11 @@ export const MapComponent: React.FC<MapComponentProps> = ({
       >
         <Geojson
           geojson={downtownBuildings as GeoJSON.FeatureCollection}
-          fillColor={fillColor}
+          fillColor={theme.colors.primary}
         />
         <Geojson
           geojson={loyolaBuildings as GeoJSON.FeatureCollection}
-          fillColor={fillColor}
+          fillColor={theme.colors.primary}
         />
         <NavigationPolyline />
 
@@ -66,8 +64,8 @@ export const MapComponent: React.FC<MapComponentProps> = ({
                 },
               ],
             }}
-            fillColor={currentBuildingFillColor}
-            strokeColor={currentBuildingStrokeColor}
+            fillColor={theme.colors.currentBuildingFillColor}
+            strokeColor={theme.colors.currentBuildingStrokeColor}
             strokeWidth={3}
           />
         )}

--- a/Polaris-FE/components/__tests__/Map.test.tsx
+++ b/Polaris-FE/components/__tests__/Map.test.tsx
@@ -126,8 +126,9 @@ describe('MapComponent', () => {
     const geojsons = UNSAFE_getAllByType(Geojson);
     const currentBuildingGeojson = geojsons.find(
       g =>
-        g.props.fillColor === 'rgba(0, 0, 255, 0.5)' &&
-        g.props.strokeColor === 'rgba(0, 0, 255, 1)' &&
+        g.props.fillColor === themes.default.colors.currentBuildingFillColor &&
+        g.props.strokeColor ===
+          themes.default.colors.currentBuildingStrokeColor &&
         g.props.strokeWidth === 3
     );
     expect(currentBuildingGeojson).toBeTruthy();

--- a/Polaris-FE/utils/themeOptions.ts
+++ b/Polaris-FE/utils/themeOptions.ts
@@ -2,6 +2,8 @@ import { DarkTheme, DefaultTheme, Theme } from '@react-navigation/native';
 
 export interface CustomTheme extends Theme {
   colors: Theme['colors'] & {
+    currentBuildingFillColor: string;
+    currentBuildingStrokeColor: string;
     secondary: string;
   };
 }
@@ -15,6 +17,8 @@ export const themes: { [key: string]: CustomTheme } = {
       ...DefaultTheme.colors,
       primary: 'rgba(143, 34, 54, 1)',
       secondary: 'rgba(143, 34, 54, 0.5)',
+      currentBuildingFillColor: 'rgba(0, 0, 255, 0.5)',
+      currentBuildingStrokeColor: 'rgba(0, 0, 255, 1)',
     },
   },
   dark: {
@@ -23,6 +27,8 @@ export const themes: { [key: string]: CustomTheme } = {
       ...DarkTheme.colors,
       primary: 'rgba(143, 34, 54, 1)',
       secondary: 'rgba(143, 34, 54, 0.5)',
+      currentBuildingFillColor: 'rgba(0, 255, 255, 0.5)',
+      currentBuildingStrokeColor: 'rgba(0, 200, 200, 1)',
     },
     fonts: fonts,
   },
@@ -36,6 +42,8 @@ export const themes: { [key: string]: CustomTheme } = {
       text: 'black',
       border: 'rgba(169, 169, 169, 1)',
       notification: 'rgba(255, 0, 0, 1)',
+      currentBuildingFillColor: 'rgba(135, 206, 250, 0.5)',
+      currentBuildingStrokeColor: 'rgba(72, 61, 139, 1)',
     },
     fonts: fonts,
   },
@@ -49,6 +57,8 @@ export const themes: { [key: string]: CustomTheme } = {
       text: 'black',
       border: 'rgba(169, 169, 169, 1)',
       notification: 'rgba(255, 0, 255, 1)',
+      currentBuildingFillColor: 'rgba(255, 223, 0, 0.5)',
+      currentBuildingStrokeColor: 'rgba(255, 165, 0, 1)',
     },
     fonts: fonts,
   },
@@ -62,6 +72,8 @@ export const themes: { [key: string]: CustomTheme } = {
       text: 'black',
       border: 'rgba(169, 169, 169, 1)',
       notification: 'rgba(255, 0, 0, 1)',
+      currentBuildingFillColor: 'rgba(255, 255, 0, 0.5)',
+      currentBuildingStrokeColor: 'rgba(0, 128, 255, 1)',
     },
     fonts: fonts,
   },


### PR DESCRIPTION
## 🐛 Bug Fix:
The building the user is located in (a.k.a the current building) loses its distinct coloring when the app's theme is changed. Its impact is fairly big as it erases a whole feature for colorblind people.


---

### ✅ **Changes Made**

- [x] Created additional properties in the themes corresponding to the current building
- [x] Had the current building change to appropriate colors for each theme
- [x] Fixed affected unit test (loading the current building Geojson in Map.test.tsx)

---
### 🔬 **How to Test**
<!-- Provide clear steps to test the implementation. -->
1. Open the app with your current location set to being inside a campus building.
2. Open the colorblind mode menu ("Modes" on the top right).
3. Toggle through all the modes to see the crrent building's color changing while still being distinct from other buildings and adhering to the theme's color palette.

---

### 🛠 **Environment**
- **OS:** MacOS 15
- **Browser:** NA
- **Device:** IOS Simulator

---

### 🎯 **Associated User Stories**

- #52  
- #89 

---

### 📸 **Screenshots/Logs (if applicable)**

https://github.com/user-attachments/assets/fd947292-25b4-4a20-835e-b5765cf48f6a

---

### 🔍 **Checkout**

- [x] SonarQube Pass
- [x] CodeCov Pass

---