### PR TITLE
Added error handling and loading state for fetching routes

### DIFF
--- a/Polaris-FE/app/__tests__/homescreen.test.tsx
+++ b/Polaris-FE/app/__tests__/homescreen.test.tsx
@@ -36,6 +36,18 @@ jest.mock('react-native-reanimated', () => {
   return Reanimated;
 });
 
+jest.mock('sonner-native', () => {
+  const React = require('react');
+  const { View, Text } = require('react-native');
+  return {
+    Toaster: () => (
+      <View testID="toaster">
+        <Text>Toaster</Text>
+      </View>
+    ),
+  };
+});
+
 describe('HomeScreen Minimal Test', () => {
   it('renders without crashing and displays "Campus"', async () => {
     const queryClient = createTestQueryClient();

--- a/Polaris-FE/app/index.tsx
+++ b/Polaris-FE/app/index.tsx
@@ -9,6 +9,7 @@ import { MapButtons } from '@/components/MapButtons';
 import { useMapLocation } from '@/hooks/useMapLocation';
 import useClarity from '@/hooks/useClarity';
 import { ColorblindButton } from '@/components/ColorblindButton';
+import { Toaster } from 'sonner-native';
 
 export default function HomeScreen() {
   const { region, setRegion } = useMapLocation();
@@ -29,6 +30,11 @@ export default function HomeScreen() {
           toggleAnimation={toggleAnimation}
           animatedPosition={animatedPosition}
           optionsAnimation={optionsAnimation}
+        />
+        <Toaster
+          toastOptions={{
+            style: { backgroundColor: '#222' },
+          }}
         />
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/Polaris-FE/components/Navigation/Navigation.tsx
+++ b/Polaris-FE/components/Navigation/Navigation.tsx
@@ -5,7 +5,7 @@ import { NavigationInfo } from '@/components/Navigation/NavigationInfo';
 import { useNavigation } from '@/contexts/NavigationContext/NavigationContext';
 
 export const Navigation: React.FC = () => {
-  const { navigationState, routeData } = useNavigation();
+  const { navigationState } = useNavigation();
 
   return (
     <React.Fragment>
@@ -13,8 +13,9 @@ export const Navigation: React.FC = () => {
 
       {navigationState === 'navigating' && <Instructions />}
 
-      {(navigationState === 'planning' || navigationState === 'navigating') &&
-        routeData && <NavigationInfo />}
+      {(navigationState === 'planning' || navigationState === 'navigating') && (
+        <NavigationInfo />
+      )}
     </React.Fragment>
   );
 };

--- a/Polaris-FE/components/Navigation/NavigationInfo.tsx
+++ b/Polaris-FE/components/Navigation/NavigationInfo.tsx
@@ -29,6 +29,28 @@ export const NavigationInfo: React.FC = () => {
     loading,
   } = useNavigation();
 
+  function routeEstimates() {
+    if (loading) {
+      return <ActivityIndicator />;
+    } else if (error) {
+      return <Text style={styles.greyText}>Directions Not Available</Text>;
+    } else if (routeData && remainingTime && remainingDistance) {
+      return (
+        <React.Fragment>
+          <Text style={styles.whiteText}>
+            {Math.ceil(remainingTime / 60)} Minutes
+          </Text>
+          <Text style={styles.whiteText}>·</Text>
+          <Text style={styles.greyText}>
+            {(remainingDistance / 1000).toFixed(1)} km
+          </Text>
+        </React.Fragment>
+      );
+    } else {
+      return <ActivityIndicator />;
+    }
+  }
+
   const handlePress = () => {
     handleGoButton({
       navigationState,
@@ -53,29 +75,7 @@ export const NavigationInfo: React.FC = () => {
         <FontAwesome5 name="times" size={20} color="white" />
       </TouchableOpacity>
 
-      {loading ? (
-        <View style={styles.infoContainer}>
-          <ActivityIndicator />
-        </View>
-      ) : error ? (
-        <View style={styles.infoContainer}>
-          <Text style={styles.greyText}>Directions Not Available</Text>
-        </View>
-      ) : routeData && remainingTime && remainingDistance ? (
-        <View style={styles.infoContainer}>
-          <Text style={styles.whiteText}>
-            {Math.ceil(remainingTime / 60)} Minutes
-          </Text>
-          <Text style={styles.whiteText}>·</Text>
-          <Text style={styles.greyText}>
-            {(remainingDistance / 1000).toFixed(1)} km
-          </Text>
-        </View>
-      ) : (
-        <View style={styles.infoContainer}>
-          <ActivityIndicator />
-        </View>
-      )}
+      <View style={styles.infoContainer}>{routeEstimates()}</View>
 
       <TouchableOpacity
         testID="action-button"

--- a/Polaris-FE/components/Navigation/NavigationInfo.tsx
+++ b/Polaris-FE/components/Navigation/NavigationInfo.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
 import { FontAwesome5 } from '@expo/vector-icons';
-import { handleTransitNavigation } from '@/utils/navigationUtils';
+import { handleGoButton } from '@/utils/navigationUtils';
 import { mapRef } from '@/utils/refs';
 import { useMapLocation } from '@/hooks/useMapLocation';
 import { useNavigation } from '@/contexts/NavigationContext/NavigationContext';
@@ -18,10 +24,13 @@ export const NavigationInfo: React.FC = () => {
     cancelNavigation,
     handleStartNavigation,
     navigationState,
+    routeData,
+    error,
+    loading,
   } = useNavigation();
 
   const handlePress = () => {
-    handleTransitNavigation({
+    handleGoButton({
       navigationState,
       is3d,
       location,
@@ -30,6 +39,7 @@ export const NavigationInfo: React.FC = () => {
       setIs3d,
       handleStartNavigation,
       mapRef,
+      error,
     });
   };
 
@@ -43,15 +53,29 @@ export const NavigationInfo: React.FC = () => {
         <FontAwesome5 name="times" size={20} color="white" />
       </TouchableOpacity>
 
-      <View style={styles.infoContainer}>
-        <Text style={styles.timeText}>
-          {Math.ceil(remainingTime / 60)} Minutes
-        </Text>
-        <Text style={styles.timeText}>·</Text>
-        <Text style={styles.distanceText}>
-          {(remainingDistance / 1000).toFixed(1)} km
-        </Text>
-      </View>
+      {loading ? (
+        <View style={styles.infoContainer}>
+          <ActivityIndicator />
+        </View>
+      ) : error ? (
+        <View style={styles.infoContainer}>
+          <Text style={styles.greyText}>Directions Not Available</Text>
+        </View>
+      ) : routeData && remainingTime && remainingDistance ? (
+        <View style={styles.infoContainer}>
+          <Text style={styles.whiteText}>
+            {Math.ceil(remainingTime / 60)} Minutes
+          </Text>
+          <Text style={styles.whiteText}>·</Text>
+          <Text style={styles.greyText}>
+            {(remainingDistance / 1000).toFixed(1)} km
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.infoContainer}>
+          <ActivityIndicator />
+        </View>
+      )}
 
       <TouchableOpacity
         testID="action-button"
@@ -94,19 +118,19 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(34, 34, 34, 0.992)',
     paddingHorizontal: 20,
     borderRadius: 16,
-    minWidth: 200,
+    minWidth: 50,
     height: 46,
     flexDirection: 'row',
     justifyContent: 'space-between',
     gap: 5,
     alignItems: 'center',
   },
-  timeText: {
+  whiteText: {
     fontSize: 18,
     fontWeight: '600',
     color: 'white',
   },
-  distanceText: {
+  greyText: {
     fontSize: 18,
     color: 'rgba(255, 255, 255, 0.8)',
   },

--- a/Polaris-FE/components/Navigation/NavigationPolyline.tsx
+++ b/Polaris-FE/components/Navigation/NavigationPolyline.tsx
@@ -17,7 +17,8 @@ export const NavigationPolyline: React.FC = () => {
     <React.Fragment>
       {(navigationState === 'planning' || navigationState === 'navigating') &&
         clippedPolyline &&
-        snappedPoint && (
+        snappedPoint &&
+        destination && (
           <React.Fragment>
             <Marker
               key={theme.colors.primary}
@@ -28,7 +29,7 @@ export const NavigationPolyline: React.FC = () => {
               <Polyline
                 coordinates={clippedPolyline}
                 strokeWidth={4}
-                strokeColor={theme.colors.secondary}
+                strokeColor={theme.colors.primary}
                 lineDashPattern={[5, 10]}
               />
             ) : (

--- a/Polaris-FE/components/Navigation/__tests__/Navigation.test.tsx
+++ b/Polaris-FE/components/Navigation/__tests__/Navigation.test.tsx
@@ -36,7 +36,6 @@ describe('Navigation Component', () => {
   it('renders nothing when navigationState is not "planning" or "navigating"', () => {
     (useNavigation as jest.Mock).mockReturnValue({
       navigationState: 'default',
-      routeData: null,
     });
 
     const { queryByText } = render(<Navigation />);
@@ -45,22 +44,9 @@ describe('Navigation Component', () => {
     expect(queryByText('NavigationInfo Component')).toBeNull();
   });
 
-  it('renders only TravelModeToggle when navigationState is "planning" and no routeData is provided', () => {
+  it('renders TravelModeToggle and NavigationInfo when navigationState is "planning"', () => {
     (useNavigation as jest.Mock).mockReturnValue({
       navigationState: 'planning',
-      routeData: null,
-    });
-
-    const { getByText, queryByText } = render(<Navigation />);
-    expect(getByText('TravelModeToggle Component')).toBeTruthy();
-    expect(queryByText('NavigationInfo Component')).toBeNull();
-    expect(queryByText('Instructions Component')).toBeNull();
-  });
-
-  it('renders TravelModeToggle and NavigationInfo when navigationState is "planning" and routeData is provided', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      navigationState: 'planning',
-      routeData: { some: 'data' },
     });
 
     const { getByText, queryByText } = render(<Navigation />);
@@ -69,22 +55,9 @@ describe('Navigation Component', () => {
     expect(queryByText('Instructions Component')).toBeNull();
   });
 
-  it('renders only Instructions when navigationState is "navigating" and no routeData is provided', () => {
+  it('renders Instructions and NavigationInfo when navigationState is "navigating"', () => {
     (useNavigation as jest.Mock).mockReturnValue({
       navigationState: 'navigating',
-      routeData: null,
-    });
-
-    const { getByText, queryByText } = render(<Navigation />);
-    expect(getByText('Instructions Component')).toBeTruthy();
-    expect(queryByText('NavigationInfo Component')).toBeNull();
-    expect(queryByText('TravelModeToggle Component')).toBeNull();
-  });
-
-  it('renders Instructions and NavigationInfo when navigationState is "navigating" and routeData is provided', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      navigationState: 'navigating',
-      routeData: { some: 'data' },
     });
 
     const { getByText, queryByText } = render(<Navigation />);

--- a/Polaris-FE/components/Navigation/__tests__/NavigationInfo.test.tsx
+++ b/Polaris-FE/components/Navigation/__tests__/NavigationInfo.test.tsx
@@ -3,9 +3,10 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { NavigationInfo } from '@/components/Navigation/NavigationInfo';
 import { useMapLocation } from '@/hooks/useMapLocation';
 import { useNavigation } from '@/contexts/NavigationContext/NavigationContext';
-import { handleTransitNavigation } from '@/utils/navigationUtils';
+import { handleGoButton } from '@/utils/navigationUtils';
 import { mapRef } from '@/utils/refs';
 import { LatLng } from 'react-native-maps';
+import '@testing-library/jest-native/extend-expect';
 
 jest.mock('@/hooks/useMapLocation');
 jest.mock('@/contexts/NavigationContext/NavigationContext');
@@ -29,190 +30,266 @@ describe('NavigationInfo', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-
     (useMapLocation as jest.Mock).mockReturnValue({
       location: mockLocation,
     });
+  });
 
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 1800,
-      remainingDistance: 15000,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'planning',
+  describe('when data is available (not loading and no error)', () => {
+    beforeEach(() => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+    });
+
+    test('renders correctly in planning state', () => {
+      const { getByText, getByTestId } = render(<NavigationInfo />);
+      expect(getByText('30 Minutes')).toBeTruthy();
+      expect(getByText('15.0 km')).toBeTruthy();
+      expect(getByText('GO')).toBeTruthy();
+
+      const actionButton = getByTestId('action-button');
+      expect(actionButton.props.style).toMatchObject(
+        expect.objectContaining({
+          backgroundColor: '#9A2E3F',
+        })
+      );
+    });
+
+    test('renders correctly in navigating state', () => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'navigating',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+      const { queryByText, getByTestId } = render(<NavigationInfo />);
+      expect(queryByText('GO')).toBeNull();
+      const actionButton = getByTestId('action-button');
+      expect(actionButton.props.style).toMatchObject(
+        expect.objectContaining({
+          backgroundColor: 'rgba(34, 34, 34, 0.992)',
+        })
+      );
+    });
+
+    test('rounds up remaining time to nearest minute', () => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 138,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+      const { getByText } = render(<NavigationInfo />);
+      expect(getByText('3 Minutes')).toBeTruthy();
+    });
+
+    test('formats distance with one decimal place', () => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 12340,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+      const { getByText } = render(<NavigationInfo />);
+      expect(getByText('12.3 km')).toBeTruthy();
     });
   });
 
-  test('renders correctly in planning state', () => {
-    const { getByText, getByTestId } = render(<NavigationInfo />);
-
-    expect(getByText('30 Minutes')).toBeTruthy();
-    expect(getByText('15.0 km')).toBeTruthy();
-
-    expect(getByText('GO')).toBeTruthy();
-
-    const actionButton = getByTestId('action-button');
-    expect(actionButton.props.style).toMatchObject(
-      expect.objectContaining({
-        backgroundColor: '#9A2E3F',
-      })
-    );
-  });
-
-  test('renders correctly in navigating state', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 1800,
-      remainingDistance: 15000,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'navigating',
+  describe('when loading is true', () => {
+    beforeEach(() => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: true,
+        error: null,
+      });
     });
 
-    const { queryByText, getByTestId } = render(<NavigationInfo />);
-
-    expect(queryByText('GO')).toBeNull();
-
-    const actionButton = getByTestId('action-button');
-    expect(actionButton.props.style).toMatchObject(
-      expect.objectContaining({
-        backgroundColor: 'rgba(34, 34, 34, 0.992)',
-      })
-    );
-  });
-
-  test('rounds up remaining time to nearest minute', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 138,
-      remainingDistance: 15000,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'planning',
-    });
-
-    const { getByText } = render(<NavigationInfo />);
-
-    expect(getByText('3 Minutes')).toBeTruthy();
-  });
-
-  test('formats distance with one decimal place', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 1800,
-      remainingDistance: 12340,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'planning',
-    });
-
-    const { getByText } = render(<NavigationInfo />);
-
-    expect(getByText('12.3 km')).toBeTruthy();
-  });
-
-  test('calls cancelNavigation when cancel button is pressed', () => {
-    const { getByTestId } = render(<NavigationInfo />);
-
-    fireEvent.press(getByTestId('cancel-button'));
-
-    expect(mockCancelNavigation).toHaveBeenCalledTimes(1);
-  });
-
-  test('calls handleTransitNavigation with correct params when GO button is pressed in planning state', () => {
-    const { getByTestId } = render(<NavigationInfo />);
-
-    fireEvent.press(getByTestId('action-button'));
-
-    expect(handleTransitNavigation).toHaveBeenCalledWith({
-      navigationState: 'planning',
-      is3d: true,
-      location: mockLocation,
-      travelMode: 'DRIVE',
-      destination: mockDestination,
-      setIs3d: mockSetIs3d,
-      handleStartNavigation: mockHandleStartNavigation,
-      mapRef,
+    test('renders an ActivityIndicator in infoContainer', () => {
+      const { toJSON } = render(<NavigationInfo />);
+      const tree = toJSON();
+      expect(JSON.stringify(tree)).toContain('ActivityIndicator');
     });
   });
 
-  test('calls handleTransitNavigation with correct params when action button is pressed in navigating state', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 1800,
-      remainingDistance: 15000,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'navigating',
+  describe('when error is present', () => {
+    beforeEach(() => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: new Error('Some error'),
+      });
     });
 
-    const { getByTestId } = render(<NavigationInfo />);
-
-    fireEvent.press(getByTestId('action-button'));
-
-    expect(handleTransitNavigation).toHaveBeenCalledWith({
-      navigationState: 'navigating',
-      is3d: true,
-      location: mockLocation,
-      travelMode: 'DRIVE',
-      destination: mockDestination,
-      setIs3d: mockSetIs3d,
-      handleStartNavigation: mockHandleStartNavigation,
-      mapRef,
+    test('renders error message', () => {
+      const { getByText } = render(<NavigationInfo />);
+      expect(getByText('Directions Not Available')).toBeTruthy();
     });
   });
 
-  test('handles zero remaining time and distance', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 0,
-      remainingDistance: 0,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'planning',
+  describe('cancel button and handleGoButton', () => {
+    beforeEach(() => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
     });
 
-    const { getByText } = render(<NavigationInfo />);
+    test('calls cancelNavigation when cancel button is pressed', () => {
+      const { getByTestId } = render(<NavigationInfo />);
+      fireEvent.press(getByTestId('cancel-button'));
+      expect(mockCancelNavigation).toHaveBeenCalledTimes(1);
+    });
 
-    expect(getByText('0 Minutes')).toBeTruthy();
-    expect(getByText('0.0 km')).toBeTruthy();
+    test('calls handleGoButton with correct params when GO button is pressed in planning state', () => {
+      const { getByTestId } = render(<NavigationInfo />);
+      fireEvent.press(getByTestId('action-button'));
+      expect(handleGoButton).toHaveBeenCalledWith({
+        navigationState: 'planning',
+        is3d: true,
+        location: mockLocation,
+        travelMode: 'DRIVE',
+        destination: mockDestination,
+        setIs3d: mockSetIs3d,
+        handleStartNavigation: mockHandleStartNavigation,
+        mapRef,
+        error: null,
+      });
+    });
+
+    test('calls handleGoButton with correct params when action button is pressed in navigating state', () => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 1800,
+        remainingDistance: 15000,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'navigating',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+      const { getByTestId } = render(<NavigationInfo />);
+      fireEvent.press(getByTestId('action-button'));
+      expect(handleGoButton).toHaveBeenCalledWith({
+        navigationState: 'navigating',
+        is3d: true,
+        location: mockLocation,
+        travelMode: 'DRIVE',
+        destination: mockDestination,
+        setIs3d: mockSetIs3d,
+        handleStartNavigation: mockHandleStartNavigation,
+        mapRef,
+        error: null,
+      });
+    });
   });
 
-  test('handles very small remaining time and distance', () => {
-    (useNavigation as jest.Mock).mockReturnValue({
-      travelMode: 'DRIVE',
-      is3d: true,
-      setIs3d: mockSetIs3d,
-      remainingTime: 5,
-      remainingDistance: 10,
-      destination: mockDestination,
-      cancelNavigation: mockCancelNavigation,
-      handleStartNavigation: mockHandleStartNavigation,
-      navigationState: 'planning',
+  describe('edge cases for time and distance', () => {
+    test('handles zero remaining time and distance by rendering loading indicator', () => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 0,
+        remainingDistance: 0,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+      const { toJSON } = render(<NavigationInfo />);
+      const tree = toJSON();
+      expect(JSON.stringify(tree)).toContain('ActivityIndicator');
     });
 
-    const { getByText } = render(<NavigationInfo />);
-
-    expect(getByText('1 Minutes')).toBeTruthy();
-    expect(getByText('0.0 km')).toBeTruthy();
+    test('handles very small remaining time and distance', () => {
+      (useNavigation as jest.Mock).mockReturnValue({
+        travelMode: 'DRIVE',
+        is3d: true,
+        setIs3d: mockSetIs3d,
+        remainingTime: 5,
+        remainingDistance: 10,
+        destination: mockDestination,
+        cancelNavigation: mockCancelNavigation,
+        handleStartNavigation: mockHandleStartNavigation,
+        navigationState: 'planning',
+        routeData: {},
+        loading: false,
+        error: null,
+      });
+      const { getByText } = render(<NavigationInfo />);
+      expect(getByText('1 Minutes')).toBeTruthy();
+      expect(getByText('0.0 km')).toBeTruthy();
+    });
   });
 });

--- a/Polaris-FE/components/Navigation/__tests__/NavigationPolyline.test.tsx
+++ b/Polaris-FE/components/Navigation/__tests__/NavigationPolyline.test.tsx
@@ -97,7 +97,7 @@ describe('NavigationPolyline Component', () => {
     expect(polylineElements).toHaveLength(1);
     expect(polylineElements[0].props.strokeWidth).toBe(4);
     expect(polylineElements[0].props.strokeColor).toBe(
-      mockTheme.colors.secondary
+      mockTheme.colors.primary
     );
     expect(polylineElements[0].props.lineDashPattern).toEqual([5, 10]);
   });

--- a/Polaris-FE/hooks/__tests__/useGoogleMapsRoute.test.ts
+++ b/Polaris-FE/hooks/__tests__/useGoogleMapsRoute.test.ts
@@ -82,6 +82,8 @@ describe('useGoogleMapsRoute', () => {
 
     expect(getGoogleMapsRoute).not.toHaveBeenCalled();
     expect(result.current.routeData).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   test('should not fetch route data when navigationState is default', async () => {
@@ -93,6 +95,8 @@ describe('useGoogleMapsRoute', () => {
 
     expect(getGoogleMapsRoute).not.toHaveBeenCalled();
     expect(result.current.routeData).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   test('should fetch route data and set it when origin and destination are provided', async () => {
@@ -119,10 +123,11 @@ describe('useGoogleMapsRoute', () => {
       mockTravelMode
     );
     expect(result.current.routeData).toEqual(mockRouteData);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   test('should fit map to coordinates when navigationState is planning', async () => {
-    // Removed unused result constant
     renderHook(() =>
       useGoogleMapsRoute(
         mockOrigin,
@@ -168,13 +173,10 @@ describe('useGoogleMapsRoute', () => {
   });
 
   test('should handle errors when fetching route data fails', async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
     const error = new Error('Network error');
     (getGoogleMapsRoute as jest.Mock).mockRejectedValue(error);
 
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useGoogleMapsRoute(
         mockOrigin,
         mockDestination,
@@ -187,12 +189,9 @@ describe('useGoogleMapsRoute', () => {
       await new Promise(resolve => setTimeout(resolve, 0));
     });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Failed to fetch route data:',
-      error
-    );
-
-    consoleErrorSpy.mockRestore();
+    expect(result.current.error).toEqual(error);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.routeData).toBeNull();
   });
 
   test('should update route data when setRouteData is called', async () => {
@@ -252,10 +251,12 @@ describe('useGoogleMapsRoute', () => {
     });
 
     expect(result.current.routeData).toEqual(newRouteData);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   test('should refetch route data when travelMode changes', async () => {
-    const { rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ travelMode, destination }) =>
         useGoogleMapsRoute(
           mockOrigin,
@@ -281,6 +282,8 @@ describe('useGoogleMapsRoute', () => {
       mockDestination,
       'DRIVE'
     );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
 
     jest.clearAllMocks();
 
@@ -302,10 +305,12 @@ describe('useGoogleMapsRoute', () => {
       }),
       'WALK'
     );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 
   test('should refetch route data when destination changes', async () => {
-    const { rerender } = renderHook(
+    const { result, rerender } = renderHook(
       ({ destination, travelMode }) =>
         useGoogleMapsRoute(
           mockOrigin,
@@ -345,5 +350,7 @@ describe('useGoogleMapsRoute', () => {
       newDestination,
       mockTravelMode
     );
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/Polaris-FE/package-lock.json
+++ b/Polaris-FE/package-lock.json
@@ -35,6 +35,7 @@
         "expo-status-bar": "~2.0.1",
         "expo-symbols": "~0.2.1",
         "expo-system-ui": "~4.0.7",
+        "expo-updates": "^0.27.4",
         "expo-web-browser": "~14.0.2",
         "firebase": "^11.2.0",
         "lucide-react-native": "^0.473.0",
@@ -55,7 +56,8 @@
         "react-native-svg": "15.8.0",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.19.13",
-        "react-native-webview": "13.12.5"
+        "react-native-webview": "13.12.5",
+        "sonner-native": "^0.17.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -2550,13 +2552,14 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-10.0.10.tgz",
-      "integrity": "sha512-wI9/iam3Irk99ADGM/FyD7YrrEibIZXR4huSZiU5zt9o3dASOKhqepiNJex4YPiktLfKhYrpSEJtwno1g0SrgA==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-10.0.11.tgz",
+      "integrity": "sha512-nociJ4zr/NmbVfMNe9j/+zRlt7wz/siISu7PjdWE4WE+elEGxWWxsGzltdJG0llzrM+khx8qUiFK5aiVcdMBww==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~9.0.15",
-        "@expo/config-types": "^52.0.4",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/config-types": "^52.0.5",
         "@expo/json-file": "^9.0.2",
         "deepmerge": "^4.3.1",
         "getenv": "^1.0.0",
@@ -2570,9 +2573,10 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "9.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.16.tgz",
-      "integrity": "sha512-AnJzmFB7ztM0JZBn+Ut6BQYC2WeGDzfIhBZVOIPMQbdBqvwJ7TmFEsGTGSxdwU/VqJaJK2sWxyt1zbWkpIYCEA==",
+      "version": "9.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-9.0.17.tgz",
+      "integrity": "sha512-m24F1COquwOm7PBl5wRbkT9P9DviCXe0D7S7nQsolfbhdCWuvMkfXeoWmgjtdhy7sDlOyIgBrAdnB6MfsWKqIg==",
+      "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^52.0.5",
         "@expo/json-file": "~9.0.2",
@@ -12325,6 +12329,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.13.3.tgz",
+      "integrity": "sha512-t+1F1tiDocSot8iSnrn/CjTUMvVvPV2DpafSVcticpbSzMGybEN7wcamO1t18fK7WxGXpZE9gxtd80qwv/LLqQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.0.11.tgz",
@@ -12357,6 +12367,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.14.0.tgz",
+      "integrity": "sha512-xjGfK9dL0B1wLnOqNkX0jM9p48Y0I5xEPzHude28LY67UmamUyAACkqhZGaPClyPNfdzczk7Ej6WaRMT3HfXvw==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.0.3.tgz",
@@ -12383,6 +12399,19 @@
       "version": "18.0.7",
       "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.0.7.tgz",
       "integrity": "sha512-EPN5yTtDCH3EMiJpJFCWuD+vJkhVbl1j3tMYo3wkhGJN7xlvZf6naLXj8vYntdXSa5M40KjOgjaRiUUqf6+dXw==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.15.7.tgz",
+      "integrity": "sha512-IVzLcPamzUi4Br96xw6JPHaa1vjYupUnMqYyV1Mtd9VQojS5hJsf5VcVzbAMZE/cFGzWLZ1oJa6QXxYjN39Uww==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~10.0.10",
+        "expo-json-utils": "~0.14.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -12525,6 +12554,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.0.0.tgz",
+      "integrity": "sha512-uPiwZjWq3AdFGgY52+I2nGPrNa6izxAglymPXHUZLekZW290GqIUOk7MBNDD4sg4JwUbSi3gdxEurpEvuq+FSg==",
+      "license": "MIT"
+    },
     "node_modules/expo-symbols": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/expo-symbols/-/expo-symbols-0.2.2.tgz",
@@ -12554,6 +12589,50 @@
           "optional": true
         }
       }
+    },
+    "node_modules/expo-updates": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.27.4.tgz",
+      "integrity": "sha512-0rg4L2fFPEjTR/qnZ9Te4Q4irVC8uvNcTZW1pWnWbadG1SLv2PKjS1MYX5BboKzC3ao0H7m++5TP3hWhNg9org==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/config": "~10.0.11",
+        "@expo/config-plugins": "~9.0.17",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.13.3",
+        "expo-manifests": "~0.15.7",
+        "expo-structured-headers": "~4.0.0",
+        "expo-updates-interface": "~1.0.0",
+        "fast-glob": "^3.3.2",
+        "fbemitter": "^3.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.0.0.tgz",
+      "integrity": "sha512-93oWtvULJOj+Pp+N/lpTcFfuREX1wNeHtp7Lwn8EbzYYmdn37MvZU3TPW2tYYCZuhzmKEXnUblYcruYoDu7IrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/expo-web-browser": {
       "version": "14.0.2",
@@ -20824,6 +20903,25 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/sonner-native": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/sonner-native/-/sonner-native-0.17.0.tgz",
+      "integrity": "sha512-RRkgnuiuccgEDJdeYnFjPzTgunN75RVB9yFh6vc9D4QEKKITrhkBGaNz0wLY85/A5MBCMmaKtfKv/uxQDxqg+g==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.10.1",
+        "react-native-safe-area-context": ">=4.10.5",
+        "react-native-screens": ">=3.31.1",
+        "react-native-svg": ">=15.6.0"
       }
     },
     "node_modules/source-map": {

--- a/Polaris-FE/package.json
+++ b/Polaris-FE/package.json
@@ -60,6 +60,7 @@
     "expo-status-bar": "~2.0.1",
     "expo-symbols": "~0.2.1",
     "expo-system-ui": "~4.0.7",
+    "expo-updates": "^0.27.4",
     "expo-web-browser": "~14.0.2",
     "firebase": "^11.2.0",
     "lucide-react-native": "^0.473.0",
@@ -80,7 +81,8 @@
     "react-native-svg": "15.8.0",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "sonner-native": "^0.17.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/Polaris-FE/services/__tests__/googleMapsRoutes.test.ts
+++ b/Polaris-FE/services/__tests__/googleMapsRoutes.test.ts
@@ -1,5 +1,6 @@
 import { getGoogleMapsRoute } from '@/services/googleMapsRoutes';
 import polyline from '@mapbox/polyline';
+import { toast } from 'sonner-native';
 
 jest.mock('@mapbox/polyline', () => ({
   decode: jest.fn(),
@@ -13,18 +14,17 @@ jest.mock('expo-constants', () => ({
   },
 }));
 
+jest.mock('sonner-native', () => ({
+  toast: {
+    error: jest.fn(),
+  },
+}));
+
 global.fetch = jest.fn();
 
 describe('getGoogleMapsRoute', () => {
-  let consoleErrorSpy: jest.SpyInstance;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    consoleErrorSpy.mockRestore();
   });
 
   it('returns route data for a valid API response', async () => {
@@ -111,6 +111,11 @@ describe('getGoogleMapsRoute', () => {
         'WALK'
       )
     ).rejects.toThrow('No routes found in the response.');
+
+    expect(toast.error).toHaveBeenCalledWith('Directions Not Available', {
+      description: expect.stringContaining('No routes found in the response.'),
+      duration: 2000,
+    });
   });
 
   it('throws an error when no polyline is provided in route or leg', async () => {
@@ -148,6 +153,13 @@ describe('getGoogleMapsRoute', () => {
         'DRIVE'
       )
     ).rejects.toThrow('No polyline provided in route or leg.');
+
+    expect(toast.error).toHaveBeenCalledWith('Directions Not Available', {
+      description: expect.stringContaining(
+        'No polyline provided in route or leg.'
+      ),
+      duration: 2000,
+    });
   });
 
   it('propagates errors from the fetch call', async () => {
@@ -160,6 +172,11 @@ describe('getGoogleMapsRoute', () => {
         'BICYCLE'
       )
     ).rejects.toThrow('Network error');
+
+    expect(toast.error).toHaveBeenCalledWith('Directions Not Available', {
+      description: expect.stringContaining('Network error'),
+      duration: 2000,
+    });
   });
 
   it('includes routingPreference for DRIVE mode', async () => {

--- a/Polaris-FE/services/googleMapsRoutes.ts
+++ b/Polaris-FE/services/googleMapsRoutes.ts
@@ -1,6 +1,7 @@
 import Constants from 'expo-constants';
 import polyline from '@mapbox/polyline';
 import { LatLng } from 'react-native-maps';
+import { toast } from 'sonner-native';
 import { TravelMode, RouteData, Step } from '@/constants/types';
 
 const GOOGLE_MAPS_API_KEY = Constants.expoConfig?.extra
@@ -103,7 +104,10 @@ export const getGoogleMapsRoute = async (
       steps,
     };
   } catch (error) {
-    console.error('Error fetching route:', error);
+    toast.error('Directions Not Available', {
+      description: `${error instanceof Error ? error.message : 'Unknown error'}`,
+      duration: 2000,
+    });
     throw error;
   }
 };

--- a/Polaris-FE/utils/__tests__/navigationUtils.test.ts
+++ b/Polaris-FE/utils/__tests__/navigationUtils.test.ts
@@ -8,7 +8,7 @@ import {
   determineNextInstruction,
   clipPolylineFromSnappedPoint,
   openTransitInMaps,
-  startNavigation,
+  animateNavCamera,
   determineCurrentStep,
 } from '@/utils/navigationUtils';
 import { Linking, Platform } from 'react-native';
@@ -384,7 +384,7 @@ describe('navigationUtils', () => {
       const animateCameraMock = jest.fn();
       const mapRef = { current: { animateCamera: animateCameraMock } };
 
-      startNavigation(
+      animateNavCamera(
         location,
         currentStep.polyline,
         currentStep,
@@ -411,7 +411,7 @@ describe('navigationUtils', () => {
     it('should not animate the camera if location is missing or step polyline is empty', () => {
       const animateCameraMock = jest.fn();
       const mapRef = { current: { animateCamera: animateCameraMock } };
-      startNavigation(
+      animateNavCamera(
         null as unknown as GeoPoint,
         [] as any,
         { polyline: [] } as any,

--- a/Polaris-FE/utils/navigationUtils.ts
+++ b/Polaris-FE/utils/navigationUtils.ts
@@ -267,7 +267,7 @@ export const openTransitInMaps = (
     .catch(err => console.error('An error occurred', err));
 };
 
-export const startNavigation = (
+export const animateNavCamera = (
   location: LatLng,
   clippedPolyline: LatLng[],
   currentStep: Step,
@@ -335,7 +335,7 @@ export const startNavigation = (
   );
 };
 
-export const handleTransitNavigation = ({
+export const handleGoButton = ({
   navigationState,
   is3d,
   location,
@@ -344,15 +344,17 @@ export const handleTransitNavigation = ({
   setIs3d,
   handleStartNavigation,
   mapRef,
+  error,
 }: {
   navigationState: string;
   is3d: boolean;
   location: { latitude: number; longitude: number } | null;
   travelMode: string;
-  destination: LatLng;
+  destination: LatLng | null;
   setIs3d: (value: boolean) => void;
   handleStartNavigation: () => void;
   mapRef: MutableRefObject<MapView | null>;
+  error: Error | null;
 }) => {
   if (navigationState === 'navigating') {
     if (is3d) {
@@ -365,7 +367,7 @@ export const handleTransitNavigation = ({
     return;
   }
 
-  if (travelMode === 'TRANSIT' && location) {
+  if (travelMode === 'TRANSIT' && location && destination && !error) {
     openTransitInMaps(location, destination);
     return;
   }


### PR DESCRIPTION
## 🐛 Bug Fix: [UI disappears when Google Maps API fails or a route isn't available #146]
<!-- Briefly describe the bug being fixed and its impact. -->


---

### ✅ **Changes Made**
<!-- List all key changes in this PR. -->
- [X] Added a error handling for fetching routes
- [X] Added a loading state while fetching routes
- [X] Display a toast with error details if fetching fails

---
### 🔬 **How to Test**
<!-- Provide clear steps to test the implementation. -->
1. Search for a destination and press on a search result to see loading indicator while fetching route.
2. Search for a destination where a route isn't available to see the error displayed in a toast, and you'll be able to exit navigation and try again.

---

### 🛠 **Environment**
- **OS:** MacOS 15
- **Browser:** N/A
- **Device:** iOS Simulator

---

### 🎯 **Associated User Stories**
<!-- Link to any related user stories for context. -->
- #32 

---

### 📸 **Screenshots/Logs (if applicable)**
<!-- Attach any relevant screenshots or logs for verification. -->
https://github.com/user-attachments/assets/ca3f2b55-270f-4c00-9c21-4770962fcf54



---

### 🔍 **Checkout**
<!-- Attach any relevant checkouts to complete in order for the PR to be merged. -->

- [X] SonarQube Pass
- [X] CodeCov Pass
