### PR TITLE
Added Icon Next to Dropdown Button to Improve Clarity

### DIFF
--- a/Polaris-FE/components/NextClassComponent/NextClassCard.tsx
+++ b/Polaris-FE/components/NextClassComponent/NextClassCard.tsx
@@ -94,7 +94,8 @@ const NextClassCard: React.FC = () => {
               style={styles.menuButton}
               labelStyle={styles.menuText}
             >
-              {selectedCalendarName}
+              {selectedCalendarName} <Text>{''}</Text>
+              <FontAwesome name="caret-down" size={14} color="#C0C0C0" />
             </Button>
           }
         >


### PR DESCRIPTION
## 🏗️ Task Implementation:

Added a caret-down icon to the dropdown button to make it more visually clear that it is interactive. The icon is aligned properly with the text and has appropriate spacing to maintain clean UI.

---

### ✅ **Changes Made**
<!-- List all key changes in this PR. -->
- [x] Implemented a caret-down icon next to the dropdown button text.
- [x] Adjusted spacing and alignment for a balanced appearance.
- [x] Verified that the button remains fully functional with the icon addition.

---
### 🔬 **How to Test**

1. Open the app and login to Google Calendar.
2. Verify that the caret-down icon is displayed next to the text.
3. Click the button and confirm that the dropdown menu opens as expected.
4. Check that the icon and text remain properly aligned in different screen sizes.

---

### 📸 **Screenshots/Logs**

**1. Before**  
<img src="https://github.com/user-attachments/assets/b0611373-57e4-42e2-a5df-d4bf18098356" width="200"/>

**2. After**  
<img src="https://github.com/user-attachments/assets/440db080-7099-4f4d-b109-e8897dc18bc0" width="200"/>



---

### 🔍 **Checkout**

- [x] SonarQube Pass
- [x] CodeCov Pass