### PR TITLE
fixed an issue where location is being fetched each 0.01s

### DIFF
--- a/Polaris-FE/hooks/useMapLocation.ts
+++ b/Polaris-FE/hooks/useMapLocation.ts
@@ -14,7 +14,6 @@ export const useMapLocation = () => {
 
   useEffect(() => {
     let subscriber: Location.LocationSubscription | null = null;
-    let intervalId: NodeJS.Timeout | null = null;
 
     (async () => {
       try {
@@ -25,11 +24,27 @@ export const useMapLocation = () => {
         }
 
         setPermissionStatus('granted');
+
+        const currentLocation = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.High,
+        });
+        setLocation({
+          latitude: currentLocation.coords.latitude,
+          longitude: currentLocation.coords.longitude,
+        });
+
+        setRegion({
+          latitude: currentLocation.coords.latitude,
+          longitude: currentLocation.coords.longitude,
+          latitudeDelta: 0.02,
+          longitudeDelta: 0.02,
+        });
+
         subscriber = await Location.watchPositionAsync(
           {
             accuracy: Location.Accuracy.BestForNavigation,
-            timeInterval: 0,
-            distanceInterval: 0,
+            timeInterval: 1000,
+            distanceInterval: 1,
           },
           newLocation => {
             const { latitude, longitude } = newLocation.coords;
@@ -51,9 +66,6 @@ export const useMapLocation = () => {
     return () => {
       if (subscriber) {
         subscriber.remove();
-      }
-      if (intervalId) {
-        clearInterval(intervalId);
       }
     };
   }, []);


### PR DESCRIPTION
## 🐛 Bug Fix: Location infinite fetch
1. Location being fetched every 0.01s  
2. Added 2 options, fetch every 1s or if the user moves 1m. the first thing to happen will trigger a location re-fetch
---

### ✅ **Changes Made**
- [x] Add 2 options for the re-fetch
- [x] every 1 second or if the user moves 1 meter, which ever happens first.
---

### 🔬 **How to Test**
1. Can't test since its not a UI
2.  Dev has to monitor the location fetch request.

---

### 🛠 **Environment**
ALL

---

### 🎯 **Associated User Stories**  
N/A
---

### 📸 **Screenshots/Logs (if applicable)**  
N/A
---

### 🔍 **Checkout**
- [x] SonarQube Pass  
- [x] CodeCov Pass  

---

### 📌 **Additional Notes (Optional)**  
No unit tests required
